### PR TITLE
add  box-sizing

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,6 +1,13 @@
 .titlebar {
 	padding: 0 3px;
 	background-color: #f6f6f6;
+	box-sizing: content-box;
+}
+
+.titlebar *,
+.titlebar :before,
+.titlebar :after {
+	box-sizing: inherit;
 }
 
 .titlebar.webkit-draggable {


### PR DESCRIPTION
If page `box-sizing` is equal to `border-box`, titlebar buttons show smaller that their actual size (because paddings not affected in their size)
We could fix this by adding `box-sizing: content-box;` to `.titlebar` and `box-sizing: inherit;` to child nodes
